### PR TITLE
non-interactive downloads of updated boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ Vagrant.configure("2") do |config|
 end
 ```
 
+To enable automatic updates for a project:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+
+  config.box_updater.autoupdate = true
+
+  // ...
+
+end
+```
 ## Install from source (Advanced)
 
 1. Clone project

--- a/lib/vagrant-box-updater/action/up_box.rb
+++ b/lib/vagrant-box-updater/action/up_box.rb
@@ -98,7 +98,7 @@ module VagrantPlugins
               env[:ui].warn("Modified image detected, this update set to be ignored until next change")
 	    else
               env[:ui].warn("Modified image detected : #{box_stats['url']} #{remote_modification_attribute}")
-	      if ask_confirm(env,"Would you like to update the box? \nIf negative - we keep ignoring this update, and notify only when another update detected. \nType (Y/N)") || enable_autoupdate_flag == 'true' 
+	      if enable_autoupdate_flag == true || ask_confirm(env,"Would you like to update the box? \nIf negative - we keep ignoring this update, and notify only when another update detected. \nType (Y/N)")
                 env[:ui].info("Going to update and replace box \"#{box_name}\" now!")
                 provider = nil
                 env[:action_runner].run(Vagrant::Action.action_box_add, {

--- a/lib/vagrant-box-updater/action/up_box.rb
+++ b/lib/vagrant-box-updater/action/up_box.rb
@@ -25,6 +25,8 @@ module VagrantPlugins
             return 0
           end
 
+          enable_autoupdate_flag = env[:machine].config.box_updater.autoupdate
+
           stat_file = env[:home_path].join(box_name + ".stat")
 
           # Create empty stat file if missing 
@@ -96,7 +98,7 @@ module VagrantPlugins
               env[:ui].warn("Modified image detected, this update set to be ignored until next change")
 	    else
               env[:ui].warn("Modified image detected : #{box_stats['url']} #{remote_modification_attribute}")
-	      if ask_confirm(env,"Would you like to update the box? \nIf negative - we keep ignoring this update, and notify only when another update detected. \nType (Y/N)")
+	      if ask_confirm(env,"Would you like to update the box? \nIf negative - we keep ignoring this update, and notify only when another update detected. \nType (Y/N)") || enable_autoupdate_flag == 'true' 
                 env[:ui].info("Going to update and replace box \"#{box_name}\" now!")
                 provider = nil
                 env[:action_runner].run(Vagrant::Action.action_box_add, {

--- a/lib/vagrant-box-updater/config.rb
+++ b/lib/vagrant-box-updater/config.rb
@@ -1,8 +1,7 @@
 module VagrantPlugins
   module BoxUpdater
     class Config < Vagrant.plugin('2', :config)
-      attr_accessor :disable
-      attr_accessor :autoupdate
+      attr_accessor :disable, :autoupdate
 
       def initialize
         @disable = false

--- a/lib/vagrant-box-updater/config.rb
+++ b/lib/vagrant-box-updater/config.rb
@@ -2,13 +2,16 @@ module VagrantPlugins
   module BoxUpdater
     class Config < Vagrant.plugin('2', :config)
       attr_accessor :disable
+      attr_accessor :autoupdate
 
       def initialize
         @disable = false
+        @autoupdate = false
       end
 
       def finalize!
         @disable = false if @disable == UNSET_VALUE
+        @autoupdate = false if @autoupdate == UNSET_VALUE
       end
 
       def validate(machine)


### PR DESCRIPTION
Adding 'config.box_updater.autoupdate = true' to the Vagrantfile allows non-interactive download of updated boxes.
