### PR TITLE
Handling file:// urls. This extends support to UNC paths.

### DIFF
--- a/lib/vagrant-box-updater/util/common.rb
+++ b/lib/vagrant-box-updater/util/common.rb
@@ -1,3 +1,5 @@
+require 'open-uri'
+
 module VagrantPlugins
   module BoxUpdater
     module Util
@@ -66,6 +68,13 @@ module VagrantPlugins
         end
         
         def self.get_local_file_modification_date?(url)
+          # Sometimes local files can be referenced by a file:// URL.
+          # Cleanup the path so that File.mtime can handle the file.
+          if url.start_with?("file://")
+            url = url.slice(7..-1)
+            url = URI::decode(url)
+          end
+
           mtime = File.mtime(url)
           return { 'Last-Modified' => mtime }
         end


### PR DESCRIPTION
Patch to extend support to boxes stored on network paths (UNC paths).

We have some Vagrant boxes stored on windows network drives. When entering UNC paths into Vagrant they have to be in the file:// url format, but Ruby's File.mtime cannot handle these. This patch converts any file:// urls to proper UNC paths that can be handled by File.mtime. 
